### PR TITLE
fix: single sample anova error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue in ANOVA components that would throw an error when only a single sample was run, as ANOVA requires at least two groups to compare. These functions will now default to using only the `seurat_clusters` variable for ANOVA if only a single sample is detected in the data. 
+
 ## [0.4.3] 2025-08-26
 
 ### Updated

--- a/R/processing.R
+++ b/R/processing.R
@@ -459,10 +459,6 @@ run_abundance_anova <-
       }, mc.cores = mc_cores) %>%
       bind_rows()
 
-    if (nrow(aov_res) == 0) {
-      cli::cli_warn("ANOVA failed for the provided data. Make sure that contrast factors have at least 2 levels.")
-      return(NULL)
-    }
     aov_res <- aov_res %>%
       mutate(p_adj = p.adjust(p, method = p_adj_method)) %>%
       relocate(p_adj, .after = p)
@@ -543,10 +539,6 @@ run_proximity_anova <-
       }, mc.cores = mc_cores) %>%
       bind_rows()
 
-    if (nrow(aov_res) == 0) {
-      cli::cli_warn("ANOVA failed for the provided data. Make sure that contrast factors have at least 2 levels.")
-      return(NULL)
-    }
     aov_res <- aov_res %>%
       separate(contrast, into = c("marker_1", "marker_2"), sep = "/") %>%
       mutate(p_adj = p.adjust(p, method = p_adj_method))

--- a/R/processing.R
+++ b/R/processing.R
@@ -435,9 +435,7 @@ run_abundance_anova <-
       FetchData(object, vars = vars) %>%
       as_tibble(rownames = "comp_id")
 
-    vars <- tidy_vars(comp_meta_data, vars)
-    if (length(vars) == 0) {
-      cli::cli_abort("No valid variables provided for ANOVA.")
+      cli::cli_abort("No valid variables provided for ANOVA. Variables with only one unique value were filtered out, leaving no variables for comparison.")
     }
 
     aov_res <-

--- a/R/processing.R
+++ b/R/processing.R
@@ -337,7 +337,24 @@ summarize_colocalization_scores_per_celltype <- function(
   if (tidy) {
     mdl <-
       mdl %>%
-      tidy() %>%
+      tidy()
+
+    # Add residuals if not present (no variance in data)
+    if (!any(mdl$term == "Residuals")) {
+      mdl <-
+        mdl %>%
+        bind_rows(tibble(
+          term = "Residuals",
+          df = NA,
+          sumsq = 0,
+          meansq = 0,
+          statistic = NA,
+          p.value = NA
+        ))
+    }
+
+    mdl <-
+      mdl %>%
       mutate(
         ss_total = sum(sumsq),
         ms_error = meansq[term == "Residuals"],
@@ -354,6 +371,26 @@ summarize_colocalization_scores_per_celltype <- function(
   return(mdl)
 }
 
+#' Tidy variables by removing those with only one unique value
+#'
+#' This function selects variables from a data frame that have more than one unique value.
+#'
+#' @param df A data frame containing the variables to be checked.
+#' @param vars A character vector of variable names to be checked.
+#'
+#' @return A character vector of variable names that have more than one unique value.
+#'
+#' @noRd
+#'
+tidy_vars <-
+  function(df, vars) {
+    select(df, all_of(vars)) %>%
+      apply(2, n_distinct) %>%
+      {
+        which(. > 1)
+      } %>%
+      names()
+  }
 
 #' Run ANOVA for abundance data in a Seurat object
 #'
@@ -397,6 +434,11 @@ run_abundance_anova <-
     comp_meta_data <-
       FetchData(object, vars = vars) %>%
       as_tibble(rownames = "comp_id")
+
+    vars <- tidy_vars(comp_meta_data, vars)
+    if (length(vars) == 0) {
+      cli::cli_abort("No valid variables provided for ANOVA.")
+    }
 
     aov_res <-
       cnt_data %>%
@@ -464,6 +506,11 @@ run_proximity_anova <-
       ungroup() %>%
       select(comp_id = sample_component, all_of(vars)) %>%
       distinct()
+
+    vars <- tidy_vars(comp_meta_data, vars)
+    if (length(vars) == 0) {
+      cli::cli_abort("No valid variables provided for ANOVA.")
+    }
 
     proximity_scores_wide <-
       proximity_scores %>%

--- a/R/processing.R
+++ b/R/processing.R
@@ -505,9 +505,7 @@ run_proximity_anova <-
       select(comp_id = sample_component, all_of(vars)) %>%
       distinct()
 
-    vars <- tidy_vars(comp_meta_data, vars)
-    if (length(vars) == 0) {
-      cli::cli_abort("No valid variables provided for ANOVA.")
+      cli::cli_abort("No valid variables provided for ANOVA. All provided variables had only one unique value and were filtered out, leaving no variables for comparison.")
     }
 
     proximity_scores_wide <-

--- a/R/processing.R
+++ b/R/processing.R
@@ -435,7 +435,10 @@ run_abundance_anova <-
       FetchData(object, vars = vars) %>%
       as_tibble(rownames = "comp_id")
 
-      cli::cli_abort("No valid variables provided for ANOVA. Variables with only one unique value were filtered out, leaving no variables for comparison.")
+    vars <- tidy_vars(comp_meta_data, vars)
+    if (length(vars) == 0) {
+      cli::cli_abort("No valid variables provided for ANOVA. Variables with only one unique value were filtered out,
+                     leaving no variables for comparison.")
     }
 
     aov_res <-
@@ -505,7 +508,10 @@ run_proximity_anova <-
       select(comp_id = sample_component, all_of(vars)) %>%
       distinct()
 
-      cli::cli_abort("No valid variables provided for ANOVA. All provided variables had only one unique value and were filtered out, leaving no variables for comparison.")
+    vars <- tidy_vars(comp_meta_data, vars)
+    if (length(vars) == 0) {
+      cli::cli_abort("No valid variables provided for ANOVA. Variables with only one unique value were filtered out,
+                     leaving no variables for comparison.")
     }
 
     proximity_scores_wide <-

--- a/tests/testthat/test_processing.R
+++ b/tests/testthat/test_processing.R
@@ -1,6 +1,6 @@
 pg_data <- get_test_data()
 
-test_that("ANOVAs work as expected", {
+test_that("Abundance ANOVAs work as expected", {
   set.seed(37)
   test_data <-
     LayerData(pg_data) %>%
@@ -173,6 +173,246 @@ test_that("ANOVAs work as expected", {
       ),
       row.names = c(NA, -12L),
       class = c("tbl_df", "tbl", "data.frame")
+    )
+  )
+
+  # When there is only one sample
+
+  test_data$condition <- "one"
+
+  expect_no_error(
+    anova_res <- .run_anova(test_data, c("seurat_clusters", "condition"), response = "x", tidy = TRUE)
+  )
+  expect_null(anova_res)
+
+  pg_data_single_cond <-
+    pg_data %>%
+    subset(features = rownames(pg_data)[1:3])
+
+  pg_data_single_cond$condition <- "one"
+
+  expect_no_error(
+    anova_res <-
+      run_abundance_anova(
+        pg_data_single_cond,
+        vars = c("seurat_clusters", "condition"),
+        layer = "data",
+        mc_cores = 1,
+        p_adj_method = "bonferroni"
+      )
+  )
+
+  expect_equal(
+    anova_res,
+    structure(
+      list(
+        marker = c(
+          "B2M", "B2M", "CD11b", "CD11b", "HLA-ABC",
+          "HLA-ABC"
+        ),
+        term = c(
+          "seurat_clusters", "Residuals", "seurat_clusters",
+          "Residuals", "seurat_clusters", "Residuals"
+        ),
+        df = c(
+          2, 27, 2,
+          27, 2, 27
+        ),
+        sumsq = c(
+          0.067520955412666, 10.8177336268987, 0.742152037086004,
+          104.397723973414, 0.0170435273467141, 4.01335386468565
+        ),
+        meansq = c(
+          0.033760477706333, 0.400656800996249, 0.371076018543002,
+          3.8665823693857, 0.00852176367335704, 0.148642735729098
+        ),
+        statistic = c(
+          0.0842628344817466, NA, 0.0959700280746785,
+          NA, 0.0573305088308384, NA
+        ),
+        p = c(
+          0.919430380488634, NA, 0.908799741070685,
+          NA, 0.944396556962291, NA
+        ),
+        p_adj = c(1, NA, 1, NA, 1, NA),
+        eta_squared = c(
+          0.00620297439091485, 0.993797025609085, 0.00705871135906503,
+          0.992941288640935, 0.00422874612325008, 0.99577125387675
+        ),
+        omega_squared = c(
+          -0.0650184660908417, NA,
+          -0.0641339311962768, NA, -0.0670589263428768, NA
+        )
+      ),
+      row.names = c(
+        NA,
+        -6L
+      ),
+      class = c("tbl_df", "tbl", "data.frame")
+    )
+  )
+})
+
+test_that("Proximity ANOVAs work as expected", {
+  set.seed(37)
+
+  con <- pixelatorR::PixelDB$new(pixelatorR::FSMap(pg_data)$pxl_file[1])
+  prox_data <-
+    con$proximity() %>%
+    group_by(marker_1, marker_2) %>%
+    filter(any(join_count > 0)) %>%
+    ungroup() %>%
+    filter(
+      marker_1 == "CD2",
+      marker_2 %in% c("CD3e", "CD2", "CD4")
+    )
+  con$close()
+
+  prox_data <-
+    prox_data %>%
+    mutate(sample_component = paste(component, "1", sep = "_")) %>%
+    select(-component) %>%
+    left_join(
+      FetchData(pg_data, c("condition", "seurat_clusters")) %>%
+        as_tibble(rownames = "sample_component"),
+      by = c("sample_component")
+    )
+
+  expect_no_error(
+    anova_res <-
+      run_proximity_anova(
+        prox_data,
+        vars = c("seurat_clusters", "condition"),
+        mc_cores = 1,
+        p_adj_method = "bonferroni"
+      )
+  )
+
+  expect_equal(
+    anova_res,
+    structure(
+      list(
+        marker_1 = c(
+          "CD2", "CD2", "CD2", "CD2", "CD2",
+          "CD2", "CD2", "CD2", "CD2"
+        ),
+        marker_2 = c(
+          "CD2", "CD2", "CD2",
+          "CD4", "CD4", "CD4", "CD3e", "CD3e", "CD3e"
+        ),
+        term = c(
+          "seurat_clusters",
+          "condition", "Residuals", "seurat_clusters", "condition", "Residuals",
+          "seurat_clusters", "condition", "Residuals"
+        ),
+        df = c(
+          2, 2, NA,
+          2, 2, NA, 2, 2, NA
+        ),
+        sumsq = c(
+          0.108108743652551, 0.246958766000748,
+          0, 0.0639945478295301, 0.0193967131662747, 0, 0.0261977319993502,
+          0.151596778712014, 0
+        ),
+        meansq = c(
+          0.0540543718262753, 0.123479383000374,
+          0, 0.031997273914765, 0.00969835658313735, 0, 0.0130988659996751,
+          0.0757983893560068, 0
+        ),
+        statistic = c(
+          NA, NA, NA, NA, NA, NA,
+          NA, NA, NA
+        ),
+        p = c(NA, NA, NA, NA, NA, NA, NA, NA, NA),
+        eta_squared = c(
+          0.304473771081201,
+          0.695526228918799, 0, 0.767401128911452, 0.232598871088548, 0,
+          0.147348373661998, 0.852651626338002, 0
+        ),
+        omega_squared = c(
+          0.304473771081201,
+          0.695526228918799, NA, 0.767401128911452, 0.232598871088548,
+          NA, 0.147348373661998, 0.852651626338002, NA
+        ),
+        p_adj = c(
+          NA_real_,
+          NA_real_, NA_real_, NA_real_, NA_real_, NA_real_, NA_real_, NA_real_,
+          NA_real_
+        )
+      ),
+      row.names = c(NA, -9L), class = c(
+        "tbl_df", "tbl",
+        "data.frame"
+      )
+    )
+  )
+
+  # Only one sample
+  prox_data$condition <- "one"
+
+  expect_no_error(
+    anova_res <-
+      run_proximity_anova(
+        prox_data,
+        vars = c("seurat_clusters", "condition"),
+        mc_cores = 1,
+        p_adj_method = "bonferroni"
+      )
+  )
+
+  expect_equal(
+    anova_res,
+    structure(
+      list(
+        marker_1 = c(
+          "CD2", "CD2", "CD2", "CD2", "CD2",
+          "CD2"
+        ),
+        marker_2 = c("CD2", "CD2", "CD4", "CD4", "CD3e", "CD3e"),
+        term = c(
+          "seurat_clusters", "Residuals", "seurat_clusters",
+          "Residuals", "seurat_clusters", "Residuals"
+        ),
+        df = c(
+          2, 2, 2,
+          2, 2, 2
+        ),
+        sumsq = c(
+          0.108108743652551, 0.246958766000748, 0.0639945478295301,
+          0.0193967131662747, 0.0261977319993502, 0.151596778712014
+        ),
+        meansq = c(
+          0.0540543718262753,
+          0.123479383000374, 0.031997273914765, 0.00969835658313735, 0.0130988659996751,
+          0.0757983893560068
+        ),
+        statistic = c(
+          0.437760300649637, NA, 3.29924700545648,
+          NA, 0.172811930582758, NA
+        ),
+        p = c(
+          0.695526228918799, NA, 0.232598871088548,
+          NA, 0.852651626338002, NA
+        ),
+        eta_squared = c(
+          0.304473771081201,
+          0.695526228918799, 0.767401128911452, 0.232598871088548, 0.147348373661998,
+          0.852651626338002
+        ),
+        omega_squared = c(
+          -0.290149250741628, NA,
+          0.479084948710154, NA, -0.494489580265652, NA
+        ),
+        p_adj = c(
+          1,
+          NA, 0.697796613265645, NA, 1, NA
+        )
+      ),
+      row.names = c(NA, -6L),
+      class = c(
+        "tbl_df",
+        "tbl", "data.frame"
+      )
     )
   )
 })


### PR DESCRIPTION
## Description

Fixed an issue in ANOVA components that would throw an error when only a single sample was run, as ANOVA requires at least two groups to compare. These functions will now default to using only the `seurat_clusters` variable for ANOVA if only a single sample is detected in the data. 

Fixes: PNA-1332

## Type of change

- [x] Bug fix 
- [ ] New feature
- [ ] Breaking change 

## How Has This Been Tested?
Tests have been added to control for this bug. 

## PR checklist:

- [x] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [x] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
