### PR TITLE
feat: locked to pixelatorR version 0.15.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pixelgentechnologies/pixelatorr:main
+FROM ghcr.io/pixelgentechnologies/pixelatorr:v0.15.0
 ARG QUARTO_VERSION="1.5.54"
 ARG GITHUB_PAT=
 # Set the environment variable for the GitHub Personal Access Token

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/pixelgentechnologies/pixelatorr:v0.15.0
+FROM ghcr.io/pixelgentechnologies/pixelatorr:sha-f48fa6d
 ARG QUARTO_VERSION="1.5.54"
 ARG GITHUB_PAT=
 # Set the environment variable for the GitHub Personal Access Token


### PR DESCRIPTION

## Description

This locks the `pixelatorES` to version v0.15.0 of `pixelatorR` to increase reproducibility and stability.

Fixes: PNA-1266

## How Has This Been Tested?

Has not been tested yet.

## PR checklist:

- [ ] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [ ] I have added tests.
- [ ] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
