### PR TITLE
Restore content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed some superfluous sequencing saturation barplot content from Quality Metrics.
+- The Key Metrics Table is now horizontal again.
 
 ## [0.9.2] 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed some superfluous sequencing saturation barplot content from Quality Metrics.
+
 ## [0.9.2] 2026-05-08
 
 ### Added 

--- a/R/key_table.R
+++ b/R/key_table.R
@@ -694,31 +694,28 @@ key_metric_table <-
       return(table_content)
     }
 
-    table_content <-
-      table_content %>%
-      purrr::map(. %>%
-        pivot_longer(
-          cols = -1,
-          names_to = "Metric",
-          values_to = "Value"
-        ) %>%
-        pivot_wider(
-          names_from = 1,
-          values_from = "Value"
-        ) %>%
-        left_join(
-          key_metric_definitions %>%
-            select(display_name, description),
-          by = c("Metric" = "display_name")
-        ) %>%
-        mutate(
-          Metric = format_with_info_bootstrap(Metric, description)
-        ) %>%
-        select(-description))
+    .add_tooltips_to_colnames <- function(tb) {
+      colnames(tb) <- vapply(
+        colnames(tb),
+        function(col) {
+          desc <- key_metric_definitions$description[
+            key_metric_definitions$display_name == col
+          ]
+          if (length(desc) == 1) {
+            format_with_info_bootstrap(col, desc)
+          } else {
+            col
+          }
+        },
+        character(1)
+      )
+      tb
+    }
 
     if (!is.null(table_content$pool)) {
       pool_table <-
         table_content$pool %>%
+        .add_tooltips_to_colnames() %>%
         style_table(
           escape = FALSE,
           tooltips = TRUE
@@ -729,6 +726,7 @@ key_metric_table <-
 
     sample_table <-
       table_content$sample %>%
+      .add_tooltips_to_colnames() %>%
       style_table(
         escape = FALSE,
         tooltips = TRUE

--- a/inst/quarto/quality_metrics.qmd
+++ b/inst/quarto/quality_metrics.qmd
@@ -113,7 +113,6 @@ plots <-
 tabset_plotlist(plots,
   level = 5
 )
-
 ```
 
 #### Reads per cell

--- a/inst/quarto/quality_metrics.qmd
+++ b/inst/quarto/quality_metrics.qmd
@@ -114,19 +114,6 @@ tabset_plotlist(plots,
   level = 5
 )
 
-component <-
-  component_sequencing_saturation(
-    qc_metrics_tables,
-    sample_levels = sample_aliases
-  )
-
-tabset_figure_table(
-  component$plots,
-  component$tabl,
-  level = 5,
-  mode = "title"
-)
-close_tabset()
 ```
 
 #### Reads per cell

--- a/inst/quarto/quality_metrics.qmd
+++ b/inst/quarto/quality_metrics.qmd
@@ -64,29 +64,6 @@ tabset_plotlist(component$sample_confidence_plots)
 
 ### Sequencing
 
-#### Reads and molecules
-
-Here we review the number of reads per stage of the `pixelator` pipeline, and the number of molecules that they are
-mapped to.
-
-```{r}
-#| label: qc_metrics_reads
-#| fig-height: 4
-#| results: 'asis'
-component <-
-  component_sequencing_reads_and_molecules(
-    sample_qc_metrics,
-    sample_levels = sample_aliases
-  )
-
-tabset_figure_table(
-  component$plots,
-  component$tabl,
-  level = 5
-)
-close_tabset()
-```
-
 #### Sequencing saturation
 
 Sequencing saturation is the fraction of a library's complexity that has been
@@ -113,6 +90,29 @@ plots <-
 tabset_plotlist(plots,
   level = 5
 )
+```
+
+#### Reads and molecules
+
+Here we review the number of reads per stage of the `pixelator` pipeline, and the number of molecules that they are
+mapped to.
+
+```{r}
+#| label: qc_metrics_reads
+#| fig-height: 4
+#| results: 'asis'
+component <-
+  component_sequencing_reads_and_molecules(
+    sample_qc_metrics,
+    sample_levels = sample_aliases
+  )
+
+tabset_figure_table(
+  component$plots,
+  component$tabl,
+  level = 5
+)
+close_tabset()
 ```
 
 #### Reads per cell
@@ -190,7 +190,7 @@ close_tabset()
 component <- component_control_markers(pg_data)
 
 tabset_figure_table(
-  list(component$p1, component$p2),
+  component$p1,
   component$tabl,
   level = 5,
   mode = "title"


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

-->

## Description

### Changed

- Removed some superfluous sequencing saturation barplot content from Quality Metrics.
- The Key Metrics Table is now horizontal again.

## Type of change

- [x] Bug fix 
- [ ] New feature
- [ ] Breaking change 

## How Has This Been Tested?

Manual testing.

## PR checklist:

- [x] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [ ] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
