### PR TITLE
Map sample names to sample alias after sample calling

### DIFF
--- a/inst/quarto/preprocessing.qmd
+++ b/inst/quarto/preprocessing.qmd
@@ -96,6 +96,24 @@ if (params$debug_mode) {
 sample_qc_metrics <-
   read_qc_files(file_paths, sample_sheet)
 
+sample_to_alias_map <- setNames(sample_sheet$sample_alias, sample_sheet$sample)
+if (!is.null(sample_qc_metrics$pool_qc_files)) {
+  for (pool_nm in names(sample_qc_metrics$pool_qc_files)) {
+    sample_calling <- sample_qc_metrics$pool_qc_files[[pool_nm]]$sample_calling
+    conf <- sample_calling$sample_confidences_per_sample
+    if (!is.null(conf) && length(conf) > 0) {
+      original_keys <- names(conf)
+      remapped_keys <- ifelse(
+        original_keys %in% names(sample_to_alias_map),
+        unname(sample_to_alias_map[original_keys]),
+        original_keys
+      )
+      names(conf) <- remapped_keys
+      sample_qc_metrics$pool_qc_files[[pool_nm]]$sample_calling$sample_confidences_per_sample <- conf
+    }
+  }
+}
+
 qc_metrics_tables <-
   get_qc_metrics(pg_data, sample_qc_metrics, sample_sheet)
 ```


### PR DESCRIPTION
## Description

I found a bug when integrating sample calling in the public pipeline. It seems like the output from sample calling uses sample names while the ES expects sample aliases.

I've come up with a fix with the help of cursor, but I'm not very familiar with this code so please shout @maxkarlsson if you think it's something else or if there is a better way to fix this. I still don't quite understand why this worked with pixelatorES-internal.

I'll leave this PR in draft until I've tested this with this PR's docker container.

Fixes: PNA-2738

## Type of change

- [X] Bug fix 
- [ ] New feature
- [ ] Breaking change 

## How Has This Been Tested?

Run the pipeline using this PR's docker container.

## PR checklist:

- [ ] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [ ] I have added tests.
- [ ] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
