### PR TITLE
fix: denoise bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.3] 2026-05-18
+
+### Fixed
+
+- Bug in `component_bleedover_noise` related to name change from `ratio` to `percent_umis_denoised`.
+
 ## [0.10.2] 2026-05-13
 
 ### Changed

--- a/R/components.R
+++ b/R/components.R
@@ -15,9 +15,9 @@ component_bleedover_noise <- function(
   pixelatorR:::assert_class(qc_metrics_tables, "list")
   p <-
     qc_metrics_tables$denoising %>%
-    ggplot(aes(sample_alias, ratio)) +
+    ggplot(aes(sample_alias, percent_umis_denoised)) +
     geom_col(fill = "#DAD6D7") +
-    geom_text(aes(label = paste0(round(ratio, 3), " %")),
+    geom_text(aes(label = paste0(round(percent_umis_denoised, 3), " %")),
       vjust = -.1,
       size = 3
     ) +

--- a/tests/testthat/test_components.R
+++ b/tests/testthat/test_components.R
@@ -148,6 +148,13 @@ for (data_type in data_types) {
       component <- component_sequencing_saturation_curve(pg_data, data_files)
     )
 
+    # component_bleedover_noise
+    expect_no_error(component <- component_bleedover_noise(qc_metrics_tables))
+    expect_s3_class(component, "ggplot")
+    expect_no_error(
+      ggplot2::ggplot_build(component)
+    )
+
     # component_abundance_per_celltype
     temp <-
       pg_data %>%


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

-->

## Description

### Fixed

- Bug in `component_bleedover_noise` related to name change from `ratio` to `percent_umis_denoised`.

## Type of change

- [x] Bug fix 
- [ ] New feature
- [ ] Breaking change 

## How Has This Been Tested?

Added new regression tests.

## PR checklist:

- [x] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [x] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
