### PR TITLE
fix: denoise bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.4] 2026-05-19
+
+### Fixed
+
+- Bug in `component_bleedover_noise` that would cause a crash if the "pool" column exists in the indata instead of "sample_alias"
+
 ## [0.10.3] 2026-05-18
 
 ### Fixed

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorES
 Title: Proxiome Experiment Summary
-Version: 0.10.3
+Version: 0.10.4
 Authors@R: 
     c(
     person("Max", "Karlsson", , "max.karlsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/components.R
+++ b/R/components.R
@@ -13,8 +13,18 @@ component_bleedover_noise <- function(
   qc_metrics_tables
 ) {
   pixelatorR:::assert_class(qc_metrics_tables, "list")
+
+  plot_data <-
+    qc_metrics_tables$denoising
+
+  if ("pool" %in% names(plot_data)) {
+    plot_data <-
+      plot_data %>%
+      rename(sample_alias = pool)
+  }
+
   p <-
-    qc_metrics_tables$denoising %>%
+    plot_data %>%
     ggplot(aes(sample_alias, percent_umis_denoised)) +
     geom_col(fill = "#DAD6D7") +
     geom_text(aes(label = paste0(round(percent_umis_denoised, 3), " %")),

--- a/inst/quarto/pixelatorES.qmd
+++ b/inst/quarto/pixelatorES.qmd
@@ -1,6 +1,6 @@
 ---
 title: "PROXIOME EXPERIMENT SUMMARY"
-subtitle: "v0.10.3"
+subtitle: "v0.10.4"
 date: "`r Sys.Date()`"
 editor_options: 
   chunk_output_type: console

--- a/tests/testthat/test_components.R
+++ b/tests/testthat/test_components.R
@@ -155,6 +155,17 @@ for (data_type in data_types) {
       ggplot2::ggplot_build(component)
     )
 
+    temp <- qc_metrics_tables
+    temp$denoising <-
+      temp$denoising %>%
+      rename(pool = 1)
+
+    expect_no_error(component <- component_bleedover_noise(temp))
+    expect_s3_class(component, "ggplot")
+    expect_no_error(
+      ggplot2::ggplot_build(component)
+    )
+
     # component_abundance_per_celltype
     temp <-
       pg_data %>%


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

-->

## Description

### Fixed

- Bug in `component_bleedover_noise` that would cause a crash if the "pool" column exists in the indata instead of "sample_alias"
- 
## Type of change

- [x] Bug fix 

## How Has This Been Tested?

Added regression test.

## PR checklist:

- [x] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [x] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
