### PR TITLE
Better errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pool` IDs with duplicates in `sample` or `sample_alias` are no longer tolerated. 
 - The chunk `read_qc_metrics` will now always throw a hard error if there is an error, regardless of which Quarto profile is used. This is to avoid silent failures in this crucial step of the data processing.
+- `get_qc_metrics` is now more lenient and will return `NULL` for extracted tables with zero rows rather than throwing an error. 
 
 ## [0.10.4] 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.10.5] 2026-05-21
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- Added an explicit title level for the tab set `component$sample_confidence_plots`.
-
 ## [0.10.5] 2026-05-21
 
 ### Changed
@@ -19,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The chunk `read_qc_metrics` will now always throw a hard error if there is an error, regardless of which Quarto profile is used. This is to avoid silent failures in this crucial step of the data processing.
 - The chunk `read_qc_metrics` will now always output messages and warnings.
 - `get_qc_metrics` is now more lenient and will return `NULL` for extracted tables with zero rows rather than throwing an error. 
+
+### Fixed
+
+- Added an explicit title level for the tab set `component$sample_confidence_plots`.
 
 ## [0.10.4] 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Added an explicit title level for the tab set `component$sample_confidence_plots`.
+
 ## [0.10.5] 2026-05-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- `pool` IDs with duplicates in `sample` or `sample_alias` are no longer tolerated. 
+- The chunk `read_qc_metrics` will now always throw a hard error if there is an error, regardless of which Quarto profile is used. This is to avoid silent failures in this crucial step of the data processing.
+
 ## [0.10.4] 2026-05-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `pool` IDs with duplicates in `sample` or `sample_alias` are no longer tolerated. 
 - The chunk `read_qc_metrics` will now always throw a hard error if there is an error, regardless of which Quarto profile is used. This is to avoid silent failures in this crucial step of the data processing.
+- The chunk `read_qc_metrics` will now always output messages and warnings.
 - `get_qc_metrics` is now more lenient and will return `NULL` for extracted tables with zero rows rather than throwing an error. 
 
 ## [0.10.4] 2026-05-19

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorES
 Title: Proxiome Experiment Summary
-Version: 0.10.4
+Version: 0.10.5
 Authors@R: 
     c(
     person("Max", "Karlsson", , "max.karlsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -45,7 +45,9 @@ globalVariables(
     "total_counts", "total_edges_in", "total_hash_counts", "total_reads",
     "type", "V1", "V2", "valid_reads", "valid_reads_saturation",
     "value", "violinwidth", "x", "xmax", "xmin", "y", "z",
-    "hjust", "sample_confidence", "cumsum_n", "text_pos"
+    "hjust", "sample_confidence", "cumsum_n", "text_pos",
+    "percent_umis_denoised", "edge_saturation", "node_saturation",
+    "saturation_mean", "saturation_se"
   ),
   package = "pixelatorES",
   add = TRUE

--- a/R/components.R
+++ b/R/components.R
@@ -442,10 +442,10 @@ component_sequencing_saturation_curve <-
       lapply(function(x) {
         df_bg <- seqsat_curve_data_mean %>%
           filter(sample_alias != x) %>%
-          na.omit()
+          stats::na.omit()
         df_fg <- seqsat_curve_data_mean %>%
           filter(sample_alias == x) %>%
-          na.omit()
+          stats::na.omit()
 
         seqsat_curve_data_mean %>%
           ggplot() +

--- a/R/key_table.R
+++ b/R/key_table.R
@@ -558,7 +558,6 @@ get_qc_metrics <-
   function(object, sample_qc_metrics, sample_sheet) {
     .format <-
       function(tb) {
-
         # If NULL return NULL
         if (is.null(tb)) {
           return(NULL)
@@ -570,7 +569,6 @@ get_qc_metrics <-
         } else if (nrow(tb) == 0) {
           # If the table is empty, return NULL
           return(NULL)
-
         }
 
         # If the table contains a "sample" column but not a "sample_alias" column, add it from samplesheet

--- a/R/key_table.R
+++ b/R/key_table.R
@@ -558,8 +558,19 @@ get_qc_metrics <-
   function(object, sample_qc_metrics, sample_sheet) {
     .format <-
       function(tb) {
+
+        # If NULL return NULL
         if (is.null(tb)) {
           return(NULL)
+        }
+
+        # If tb is a list of tables, apply formatting to each element in the list instead
+        if (inherits(tb, "list")) {
+          tb <- lapply(tb, .format)
+        } else if (nrow(tb) == 0) {
+          # If the table is empty, return NULL
+          return(NULL)
+
         }
 
         # If the table contains a "sample" column but not a "sample_alias" column, add it from samplesheet
@@ -600,11 +611,6 @@ get_qc_metrics <-
             levels = pool_levels,
             column_name = "pool"
           )
-        }
-
-        # If tb is a list of tables, apply formatting to each element in the list instead
-        if (inherits(tb, "list")) {
-          tb <- lapply(tb, .format)
         }
 
         return(tb)

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -550,13 +550,23 @@ read_samplesheet <-
       sample_sheet$condition <- NA
     }
 
-    sample_sheet %>%
+    sample_sheet <-
+      sample_sheet %>%
       select(sample, sample_alias, condition, any_of("pool")) %>%
       mutate(
         sample_alias = ifelse(is.na(sample_alias), sample, sample_alias),
         condition = ifelse(is.na(condition), sample_alias, condition)
       ) %>%
       distinct()
+
+    if ("pool" %in% names(sample_sheet)) {
+      if (any(c(sample_sheet$sample, sample_sheet$sample_alias) %in% sample_sheet$pool)) {
+        cli_abort("The `pool` column in the sample sheet cannot contain values that are also present in the `sample`
+                  or `sample_alias` columns.")
+      }
+    }
+
+    return(sample_sheet)
   }
 
 

--- a/inst/quarto/pixelatorES.qmd
+++ b/inst/quarto/pixelatorES.qmd
@@ -1,6 +1,6 @@
 ---
 title: "PROXIOME EXPERIMENT SUMMARY"
-subtitle: "v0.10.4"
+subtitle: "v0.10.5"
 date: "`r Sys.Date()`"
 editor_options: 
   chunk_output_type: console

--- a/inst/quarto/preprocessing.qmd
+++ b/inst/quarto/preprocessing.qmd
@@ -94,6 +94,8 @@ if (params$debug_mode) {
 #| label: read_qc_metrics
 #| results: 'asis'
 #| error: true
+#| warning: true
+#| message: true
 
 sample_qc_metrics <-
   read_qc_files(file_paths, sample_sheet)

--- a/inst/quarto/preprocessing.qmd
+++ b/inst/quarto/preprocessing.qmd
@@ -93,6 +93,8 @@ if (params$debug_mode) {
 ```{r}
 #| label: read_qc_metrics
 #| results: 'asis'
+#| error: true
+
 sample_qc_metrics <-
   read_qc_files(file_paths, sample_sheet)
 

--- a/inst/quarto/preprocessing.qmd
+++ b/inst/quarto/preprocessing.qmd
@@ -93,7 +93,7 @@ if (params$debug_mode) {
 ```{r}
 #| label: read_qc_metrics
 #| results: 'asis'
-#| error: true
+#| error: false
 #| warning: true
 #| message: true
 

--- a/inst/quarto/quality_metrics.qmd
+++ b/inst/quarto/quality_metrics.qmd
@@ -59,7 +59,7 @@ tabset_figure_table(
 )
 close_tabset()
 
-tabset_plotlist(component$sample_confidence_plots)
+tabset_plotlist(component$sample_confidence_plots, level = 4)
 ```
 
 ### Sequencing

--- a/tests/testthat/test_read_data.R
+++ b/tests/testthat/test_read_data.R
@@ -374,6 +374,7 @@ test_that("File reading works as expected", {
 
   # Hashing
   expect_no_error(sample_sheet_hashing <- read_samplesheet(test_samplesheet(type = "hashing")))
+
   expect_equal(
     sample_sheet_hashing,
     structure(
@@ -387,6 +388,17 @@ test_that("File reading works as expected", {
       class = c("tbl_df", "tbl", "data.frame")
     )
   )
+
+  # Error out when duplicates between pool and samples
+  temp_file <- tempfile(fileext = ".csv")
+  sample_sheet_hashing %>%
+    mutate(pool = sample) %>%
+    write.csv(temp_file)
+  expect_error(
+    suppressMessages(read_samplesheet(temp_file)),
+    regexp = "The `pool` column.*cannot contain.*also present"
+  )
+
   expect_no_error(data_paths <-
     get_file_paths(
       data_folder = test_data_folder(type = "hashing"),


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

-->

## Description

### Changed

- `pool` IDs with duplicates in `sample` or `sample_alias` are no longer tolerated. 
- The chunk `read_qc_metrics` will now always throw a hard error if there is an error, regardless of which Quarto profile is used. This is to avoid silent failures in this crucial step of the data processing.
- The chunk `read_qc_metrics` will now always output messages and warnings.
- `get_qc_metrics` is now more lenient and will return `NULL` for extracted tables with zero rows rather than throwing an error. 

## Type of change

- [x] Bug fix 
- [ ] New feature
- [ ] Breaking change 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## PR checklist:

- [x] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [ ] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
