### PR TITLE
Read samplesheet extend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.11.1] 2026-06-09
+
+### Changed
+
+- `read_samplesheet` now also returns "lot_role", "kit_lot_id" columns if they exist.
+
 ## [0.11.0] 2026-06-08
 
 ### Added

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorES
 Title: Proxiome Experiment Summary
-Version: 0.11.0
+Version: 0.11.1
 Authors@R: 
     c(
     person("Max", "Karlsson", , "max.karlsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -530,7 +530,7 @@ extract_sample_qc_metrics <-
 #' @export
 #'
 read_samplesheet <-
-  function(filepath) {
+  function(filepath, additional_columns = NULL) {
     pixelatorR:::assert_single_value(filepath, type = "string")
     pixelatorR:::assert_file_exists(filepath)
 
@@ -552,7 +552,7 @@ read_samplesheet <-
 
     sample_sheet <-
       sample_sheet %>%
-      select(sample, sample_alias, condition, any_of("pool")) %>%
+      select(sample, sample_alias, condition, any_of(c("pool", "lot_role", "kit_lot_id"))) %>%
       mutate(
         sample_alias = ifelse(is.na(sample_alias), sample, sample_alias),
         condition = ifelse(is.na(condition), sample_alias, condition)

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -524,8 +524,8 @@ extract_sample_qc_metrics <-
 #'
 #' @param filepath A character string specifying the path to the sample sheet CSV file.
 #'
-#' @return A tibble with columns `sample`, `sample_alias`, `condition`, and `pool` (the latter all
-#'   `NA` when the file has no pool column).
+#' @return A tibble with columns `sample`, `sample_alias`, `condition`. Columns `pool`, `lot_role`, and `kit_lot_id` are
+#' included if present in the CSV file.
 #'
 #' @export
 #'

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -530,7 +530,7 @@ extract_sample_qc_metrics <-
 #' @export
 #'
 read_samplesheet <-
-  function(filepath, additional_columns = NULL) {
+  function(filepath) {
     pixelatorR:::assert_single_value(filepath, type = "string")
     pixelatorR:::assert_file_exists(filepath)
 

--- a/inst/quarto/pixelatorES.qmd
+++ b/inst/quarto/pixelatorES.qmd
@@ -1,6 +1,6 @@
 ---
 title: "PROXIOME EXPERIMENT SUMMARY"
-subtitle: "v0.11.0"
+subtitle: "v0.11.1"
 date: "`r Sys.Date()`"
 editor_options: 
   chunk_output_type: console

--- a/man/read_samplesheet.Rd
+++ b/man/read_samplesheet.Rd
@@ -4,14 +4,14 @@
 \alias{read_samplesheet}
 \title{Read a sample sheet from a CSV file}
 \usage{
-read_samplesheet(filepath)
+read_samplesheet(filepath, additional_columns = NULL)
 }
 \arguments{
 \item{filepath}{A character string specifying the path to the sample sheet CSV file.}
 }
 \value{
-A tibble with columns \code{sample}, \code{sample_alias}, \code{condition}, and \code{pool} (the latter all
-\code{NA} when the file has no pool column).
+A tibble with columns \code{sample}, \code{sample_alias}, \code{condition}. Columns \code{pool}, \code{lot_role}, and \code{kit_lot_id} are
+included if present in the CSV file.
 }
 \description{
 Reads a sample sheet from a CSV file and returns it as a tibble.

--- a/man/read_samplesheet.Rd
+++ b/man/read_samplesheet.Rd
@@ -4,7 +4,7 @@
 \alias{read_samplesheet}
 \title{Read a sample sheet from a CSV file}
 \usage{
-read_samplesheet(filepath, additional_columns = NULL)
+read_samplesheet(filepath)
 }
 \arguments{
 \item{filepath}{A character string specifying the path to the sample sheet CSV file.}


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

-->

## Description

### Changed

- `read_samplesheet` now also returns "lot_role", "kit_lot_id" columns if they exist.

## Type of change

- [ ] Bug fix 
- [x] New feature
- [ ] Breaking change 

## How Has This Been Tested?

No testing.

## PR checklist:

- [x] I have run R CMD check on the package and it passes.
- [x] I have made changes to the documentation.
- [ ] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
