### PR TITLE
Add hash enrichment factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `component_hashing` now returns a sample confidence plot with either hashing purity or hash enrichment factor, depending on which of the metrics is present in the data.
 
-
 ## [0.11.1] 2026-06-09
 
 ### Changed


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

-->

## Description

### Changed

- `component_hashing` now returns a sample confidence plot with either hashing purity or hash enrichment factor, depending on which of the metrics is present in the data.

## Type of change

- [ ] Bug fix 
- [x] New feature
- [ ] Breaking change 

## How Has This Been Tested?

Manual testing.

## PR checklist:

- [ ] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [ ] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
