### PR TITLE
Fix denoise bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
  
- - `downsample_data` will now default to the number of markers or cells in the data if `n_markers` or `n_cells` are higher than available in the data.
+- `downsample_data` will now default to the number of markers or cells in the data if `n_markers` or `n_cells` are higher than available in the data.
+- Bug in `component_denoising` in the isotype reduction plot, where components with zero isotype counts would cause the summary median to become `NAs`.
 
 ## [0.11.2] 2026-06-15
 
 ### Changed
 
- - `component_hashing` now returns a sample confidence plot with either hash purity or hash enrichment factor, depending on which metric is present in the data.
+- `component_hashing` now returns a sample confidence plot with either hash purity or hash enrichment factor, depending on which metric is present in the data.
  
 ### Removed
  
- - `harmony` has been removed, and `do_harmonize` is no longer an option. 
+- `harmony` has been removed, and `do_harmonize` is no longer an option. 
  
 ## [0.11.1] 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- In-report deep-link anchor IDs for plot tabsets (`title_plotlist`, `tabset_plotlist`, `tabset_nested_plotlist`). Anchor IDs are derived from the knitr chunk label and tab name (e.g. `#abundance-per-marker-cd3`, `#qc-metrics-sequencing-saturation-s11`).
+- ES report hash navigation in `custom.html`: opens nested tab panes for `#` links, scrolls to the target, refreshes HTMLWidgets and DataTables in newly shown tabs, and restores tab/scroll state on browser back.
+
 ### Fixed
  
 - `downsample_data` will now default to the number of markers or cells in the data if `n_markers` or `n_cells` are higher than available in the data.
 - Bug in `component_denoising` in the isotype reduction plot, where components with zero isotype counts would cause the summary median to become `NAs`.
+- Tab deep-link navigation when the hash target is itself a `.tab-pane` element (the target pane was not activated).
 
 ## [0.11.2] 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.3] 2026-06-23
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  
 - `downsample_data` will now default to the number of markers or cells in the data if `n_markers` or `n_cells` are higher than available in the data.
 - Bug in `component_denoising` in the isotype reduction plot, where components with zero isotype counts would cause the summary median to become `NAs`.
-- Tab deep-link navigation when the hash target is itself a `.tab-pane` element (the target pane was not activated).
 
 ## [0.11.2] 2026-06-15
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorES
 Title: Proxiome Experiment Summary
-Version: 0.11.2
+Version: 0.11.3
 Authors@R: 
     c(
     person("Max", "Karlsson", , "max.karlsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/components.R
+++ b/R/components.R
@@ -142,7 +142,10 @@ component_denoising <- function(
 
   isotype_data <-
     qc_metrics_tables$denoising_detail$isotype_reduction %>%
-    set_sample_levels(sample_levels)
+    set_sample_levels(sample_levels) %>%
+    mutate(isotype_reduction = ifelse(is.na(isotype_reduction),
+      0, isotype_reduction
+    ))
 
   p_isotype_reduction <-
     isotype_data %>%
@@ -153,7 +156,7 @@ component_denoising <- function(
       y_label = "Isotype reduction by denoising",
       use_pct = TRUE,
       hline = 0,
-      round = 1
+      round = 2
     ) +
     scale_y_continuous(
       labels = scales::percent_format(accuracy = 1),

--- a/R/plot_helpers.R
+++ b/R/plot_helpers.R
@@ -42,6 +42,13 @@ title_plotlist <- function(plots, level = 2, anchor_prefix = NULL) {
     # Generate a header for each plot in the tabset
     cat(paste0(strrep("#", level), " ", nams[tab], "\n\n"))
 
+    if (!is.null(prefix)) {
+      cat(sprintf(
+        '<div class="plot-anchor" data-anchor-id="%s" aria-hidden="true"></div>\n\n',
+        plot_anchor_slug(prefix, nams[tab])
+      ))
+    }
+
     # Print the plot
     msg <- try(print(plots[[tab]]), silent = TRUE)
     if (inherits(msg, "try-error")) {
@@ -53,14 +60,7 @@ title_plotlist <- function(plots, level = 2, anchor_prefix = NULL) {
       )
     }
 
-    if (!is.null(prefix)) {
-      cat(sprintf(
-        '<div class="plot-anchor" data-anchor-id="%s" aria-hidden="true"></div>\n\n',
-        plot_anchor_slug(prefix, nams[tab])
-      ))
-    } else {
-      cat("\n\n")
-    }
+    cat("\n\n")
   }
 }
 

--- a/R/plot_helpers.R
+++ b/R/plot_helpers.R
@@ -1,17 +1,38 @@
+plot_anchor_slug <- function(...) {
+  x <- paste(..., collapse = "-")
+  x <- tolower(x)
+  x <- gsub("[^a-z0-9]+", "-", x)
+  gsub("^-+|-+$", "", x)
+}
+
+resolve_anchor_prefix <- function(anchor_prefix = NULL) {
+  if (is.null(anchor_prefix)) {
+    label <- knitr::opts_current$get("label")
+    if (is.null(label) || !nzchar(label)) {
+      return(NULL)
+    }
+    return(plot_anchor_slug(label))
+  }
+  anchor_prefix
+}
+
 #' Header wrap plots
 #'
 #' Wraps a list of plots with headers for each plot.
 #'
 #' @param plots List of plots to be wrapped.
 #' @param level Integer indicating the header level for the headers (default is 2).
+#' @param anchor_prefix Prefix for in-report deep-link anchor IDs. `NULL` (default)
+#'   auto-detects from the current knitr chunk label; pass a string to override.
 #'
 #' @return A formatted list of plots with headers.
 #'
 #' @export
-title_plotlist <- function(plots, level = 2) {
+title_plotlist <- function(plots, level = 2, anchor_prefix = NULL) {
   pixelatorR:::assert_class(plots, "list")
   for (plot in plots) pixelatorR:::assert_class(plot, c("ggplot", "datatables"))
 
+  prefix <- resolve_anchor_prefix(anchor_prefix)
   nams <- names(plots)
 
   if (is.null(nams)) nams <- rep(" ", length(plots))
@@ -31,7 +52,15 @@ title_plotlist <- function(plots, level = 2) {
           geom_blank()
       )
     }
-    cat("\n\n")
+
+    if (!is.null(prefix)) {
+      cat(sprintf(
+        '<div class="plot-anchor" data-anchor-id="%s" aria-hidden="true"></div>\n\n',
+        plot_anchor_slug(prefix, nams[tab])
+      ))
+    } else {
+      cat("\n\n")
+    }
   }
 }
 
@@ -42,6 +71,8 @@ title_plotlist <- function(plots, level = 2) {
 #' @param plots List of plots to be tabsetted.
 #' @param level Integer indicating the header level for the tabset title (default is 2).
 #' @param close Logical indicating whether to close the tabset after plotting (default is TRUE).
+#' @param anchor_prefix Prefix for in-report deep-link anchor IDs. `NULL` (default)
+#'   auto-detects from the current knitr chunk label; pass a string to override.
 #'
 #' @return A formatted tabset of plots.
 #'
@@ -50,15 +81,18 @@ tabset_plotlist <-
   function(
     plots,
     level = 2,
-    close = TRUE
+    close = TRUE,
+    anchor_prefix = NULL
   ) {
     pixelatorR:::assert_class(plots, "list")
     for (plot in plots) pixelatorR:::assert_class(plot, c("ggplot", "datatables"))
 
+    prefix <- resolve_anchor_prefix(anchor_prefix)
+
     # Start the tabset
     cat("::: {.panel-tabset .nav-pills}\n")
 
-    title_plotlist(plots, level)
+    title_plotlist(plots, level, anchor_prefix = prefix)
 
     # Close the tabset
     if (close) cat(":::\n")
@@ -72,6 +106,8 @@ tabset_plotlist <-
 #' @param plots List of plots or list of lists of plots to be tabsetted.
 #' @param level Integer indicating the header level for the tabset title (default is 2).
 #' @param close Logical indicating whether to close the tabset after plotting (default is TRUE).
+#' @param anchor_prefix Prefix for in-report deep-link anchor IDs. `NULL` (default)
+#'   auto-detects from the current knitr chunk label; pass a string to override.
 #'
 #' @return A formatted tabset of plots.
 #'
@@ -80,7 +116,8 @@ tabset_nested_plotlist <-
   function(
     plots,
     level = 2,
-    close = TRUE
+    close = TRUE,
+    anchor_prefix = NULL
   ) {
     pixelatorR:::assert_class(plots, "list")
     for (plot in plots) {
@@ -94,6 +131,8 @@ tabset_nested_plotlist <-
       )
     }
 
+    prefix <- resolve_anchor_prefix(anchor_prefix)
+
     # Start the tabset
     cat("\n\n")
     cat("::: {.panel-tabset .nav-pills}\n")
@@ -104,12 +143,24 @@ tabset_nested_plotlist <-
 
         cat(paste0(strrep("#", level), " ", names(plots)[tab], "\n"))
 
-        tabset_nested_plotlist(plots[[tab]], level + 1)
+        child_prefix <- if (!is.null(prefix)) {
+          plot_anchor_slug(prefix, names(plots)[tab])
+        } else {
+          NULL
+        }
+
+        tabset_nested_plotlist(
+          plots[[tab]],
+          level + 1,
+          anchor_prefix = child_prefix
+        )
       } else if (inherits(plots[[tab]], "ggplot")) {
         # Otherwise, just print the plot
-        list(plots[[tab]]) %>%
-          set_names(names(plots)[tab]) %>%
-          title_plotlist(level)
+        title_plotlist(
+          list(plots[[tab]]) %>% set_names(names(plots)[tab]),
+          level,
+          anchor_prefix = prefix
+        )
       }
     }
     # Close the tabset

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -301,7 +301,7 @@ downsample_data <-
     set.seed(37)
 
     pixelatorR:::assert_class(pg_data, "Seurat")
-    pixelatorR:::assert_vector(control_markers, "character", allow_null = TRUE)
+    pixelatorR:::assert_vector(control_markers, "character", n = 1, allow_null = TRUE)
     pixelatorR:::assert_single_value(n_cells, "integer")
     pixelatorR:::assert_single_value(n_markers, "integer")
 

--- a/inst/quarto/custom.html
+++ b/inst/quarto/custom.html
@@ -31,9 +31,16 @@ document.addEventListener("DOMContentLoaded", function() {
 
     if (window.HTMLWidgets) {
       pane.querySelectorAll(".html-widget").forEach(function(el) {
-        const widget = HTMLWidgets.find(el);
-        if (widget && typeof widget.resize === "function") {
-          widget.resize();
+        if (!el.id) {
+          return;
+        }
+        try {
+          const widget = HTMLWidgets.find(el.id);
+          if (widget && typeof widget.resize === "function") {
+            widget.resize();
+          }
+        } catch (e) {
+          // Widget not bound yet
         }
       });
     }

--- a/inst/quarto/custom.html
+++ b/inst/quarto/custom.html
@@ -104,9 +104,9 @@ document.addEventListener("DOMContentLoaded", function() {
     });
   }
 
-  function collectAncestorTabPanes(el) {
+  function collectTabPanes(el) {
     const panes = [];
-    let node = el.parentElement;
+    let node = el;
 
     while (node) {
       if (node.classList && node.classList.contains("tab-pane")) {
@@ -171,7 +171,7 @@ document.addEventListener("DOMContentLoaded", function() {
       return Promise.resolve(false);
     }
 
-    const panes = collectAncestorTabPanes(target);
+    const panes = collectTabPanes(target);
 
     return showTabPaneChain(panes).then(function() {
       requestAnimationFrame(function() {

--- a/inst/quarto/custom.html
+++ b/inst/quarto/custom.html
@@ -1,33 +1,377 @@
 <script>
 document.addEventListener("DOMContentLoaded", function() {
 
-  const tabsets = document.querySelectorAll('.panel-tabset');
+  const TOOLTIP_OPTS = { container: "body" };
 
-  tabsets.forEach(tabset => {
+  function paneIsActive(pane) {
+    return pane && pane.classList.contains("active");
+  }
 
-    tabset.addEventListener('show.bs.tab', function () {
-      // Lock height before transition to prevent page jump
-      const tabContent = tabset.querySelector('.tab-content');
+  function initTooltips(root) {
+    if (!window.bootstrap || !window.bootstrap.Tooltip) {
+      return;
+    }
+    if (!root) {
+      return;
+    }
+
+    root.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(function(el) {
+      const existing = bootstrap.Tooltip.getInstance(el);
+      if (existing) {
+        existing.dispose();
+      }
+      new bootstrap.Tooltip(el, TOOLTIP_OPTS);
+    });
+  }
+
+  function refreshPane(pane) {
+    if (!pane) {
+      return;
+    }
+
+    if (window.HTMLWidgets) {
+      pane.querySelectorAll(".html-widget").forEach(function(el) {
+        const widget = HTMLWidgets.find(el);
+        if (widget && typeof widget.resize === "function") {
+          widget.resize();
+        }
+      });
+    }
+
+    if (window.jQuery && window.jQuery.fn && window.jQuery.fn.dataTable) {
+      pane.querySelectorAll("table.dataTable").forEach(function(table) {
+        try {
+          window.jQuery(table).DataTable().columns.adjust().draw(false);
+        } catch (e) {
+          // DataTable not bound yet
+        }
+      });
+    }
+
+    initTooltips(pane);
+    window.dispatchEvent(new Event("resize"));
+  }
+
+  function schedulePaneRefresh(pane) {
+    if (!pane) {
+      return;
+    }
+
+    requestAnimationFrame(function() {
+      refreshPane(pane);
+    });
+
+    // DataTables in a newly shown tab often render after shown.bs.tab fires.
+    [50, 150, 400, 800].forEach(function(delay) {
+      setTimeout(function() {
+        if (paneIsActive(pane)) {
+          refreshPane(pane);
+        }
+      }, delay);
+    });
+  }
+
+  document.addEventListener("shown.bs.tab", function(event) {
+    const trigger = event.target;
+    if (!trigger || !trigger.getAttribute) {
+      return;
+    }
+
+    const target = trigger.getAttribute("data-bs-target");
+    if (!target) {
+      return;
+    }
+
+    schedulePaneRefresh(document.querySelector(target));
+  });
+
+  if (window.HTMLWidgets && window.HTMLWidgets.addPostRenderHandler) {
+    HTMLWidgets.addPostRenderHandler(function(el) {
+      const pane = el.closest ? el.closest(".tab-pane") : null;
+      if (!pane || paneIsActive(pane)) {
+        initTooltips(el);
+      }
+    });
+  }
+
+  if (window.jQuery) {
+    jQuery(document).on("draw.dt", function(event) {
+      const table = event.target;
+      const pane = table.closest && table.closest(".tab-pane");
+      if (!pane || paneIsActive(pane)) {
+        initTooltips(pane || table);
+      }
+    });
+  }
+
+  function collectAncestorTabPanes(el) {
+    const panes = [];
+    let node = el.parentElement;
+
+    while (node) {
+      if (node.classList && node.classList.contains("tab-pane")) {
+        panes.push(node);
+      }
+      node = node.parentElement;
+    }
+
+    return panes.reverse();
+  }
+
+  function tabTriggerForPane(pane) {
+    if (!pane || !pane.id) {
+      return null;
+    }
+
+    return document.querySelector(
+      '[data-bs-toggle="tab"][data-bs-target="#' + pane.id + '"]'
+    );
+  }
+
+  function showTabPaneChain(panes) {
+    if (!window.bootstrap || !window.bootstrap.Tab) {
+      return Promise.resolve();
+    }
+
+    return panes.reduce(function(chain, pane) {
+      return chain.then(function() {
+        return new Promise(function(resolve) {
+          const trigger = tabTriggerForPane(pane);
+
+          if (!trigger || trigger.classList.contains("active")) {
+            resolve();
+            return;
+          }
+
+          const onShown = function() {
+            trigger.removeEventListener("shown.bs.tab", onShown);
+            resolve();
+          };
+
+          trigger.addEventListener("shown.bs.tab", onShown);
+          bootstrap.Tab.getOrCreateInstance(trigger).show();
+        });
+      });
+    }, Promise.resolve());
+  }
+
+  function anchorTarget(id) {
+    const decoded = decodeURIComponent(id);
+
+    return (
+      document.getElementById(decoded) ||
+      document.querySelector('[data-anchor-id="' + decoded + '"]')
+    );
+  }
+
+  function navigateToAnchor(id) {
+    const target = anchorTarget(id);
+
+    if (!target) {
+      return Promise.resolve(false);
+    }
+
+    const panes = collectAncestorTabPanes(target);
+
+    return showTabPaneChain(panes).then(function() {
+      requestAnimationFrame(function() {
+        target.scrollIntoView({ behavior: "smooth", block: "start" });
+
+        const activePane = panes.length ? panes[panes.length - 1] : null;
+        if (activePane) {
+          schedulePaneRefresh(activePane);
+        }
+      });
+
+      return true;
+    });
+  }
+
+  function hashLinkTargetId(link) {
+    const href = link.getAttribute("href");
+
+    if (!href || href.charAt(0) !== "#" || href.length < 2) {
+      return null;
+    }
+
+    return href.slice(1);
+  }
+
+  function tabPaneDepth(pane) {
+    let depth = 0;
+    let node = pane.parentElement;
+
+    while (node) {
+      if (node.classList && node.classList.contains("tab-pane")) {
+        depth++;
+      }
+      node = node.parentElement;
+    }
+
+    return depth;
+  }
+
+  const defaultActivePanes = Array.from(document.querySelectorAll(".tab-pane.active"))
+    .sort(function(a, b) {
+      return tabPaneDepth(a) - tabPaneDepth(b);
+    });
+
+  const returnStack = [];
+  let navDepth = 0;
+  let lastNavigatedHash = window.location.hash;
+
+  function captureCurrentView() {
+    const panes = Array.from(document.querySelectorAll(".tab-pane.active"))
+      .sort(function(a, b) {
+        return tabPaneDepth(a) - tabPaneDepth(b);
+      });
+
+    return {
+      paneIds: panes.map(function(pane) {
+        return pane.id;
+      }),
+      scrollY: window.scrollY
+    };
+  }
+
+  function panesFromView(view) {
+    return view.paneIds
+      .map(function(id) {
+        return document.getElementById(id);
+      })
+      .filter(Boolean)
+      .sort(function(a, b) {
+        return tabPaneDepth(a) - tabPaneDepth(b);
+      });
+  }
+
+  function restoreDefaultView() {
+    showTabPaneChain(defaultActivePanes).then(function() {
+      requestAnimationFrame(function() {
+        window.scrollTo({ top: 0, behavior: "auto" });
+
+        const activePane = defaultActivePanes.length
+          ? defaultActivePanes[defaultActivePanes.length - 1]
+          : null;
+        if (activePane) {
+          schedulePaneRefresh(activePane);
+        }
+      });
+    });
+  }
+
+  function restoreView(view) {
+    const panes = panesFromView(view);
+
+    if (!panes.length) {
+      restoreDefaultView();
+      return;
+    }
+
+    showTabPaneChain(panes).then(function() {
+      requestAnimationFrame(function() {
+        window.scrollTo({ top: view.scrollY, behavior: "auto" });
+
+        const activePane = panes[panes.length - 1];
+        if (activePane) {
+          schedulePaneRefresh(activePane);
+        }
+      });
+    });
+  }
+
+  function handleHistoryNavigation(event, fromPopstate) {
+    const hash = window.location.hash;
+
+    if (hash === lastNavigatedHash) {
+      return;
+    }
+
+    const goingBack = fromPopstate &&
+      event.state &&
+      typeof event.state.depth === "number" &&
+      event.state.depth < navDepth;
+
+    if (fromPopstate && event.state && typeof event.state.depth === "number") {
+      navDepth = event.state.depth;
+    }
+
+    lastNavigatedHash = hash;
+
+    if (goingBack) {
+      const view = returnStack.pop();
+
+      if (view) {
+        restoreView(view);
+      } else if (hash.length > 1) {
+        navigateToAnchor(hash.slice(1));
+      } else {
+        restoreDefaultView();
+      }
+      return;
+    }
+
+    if (hash.length > 1) {
+      navigateToAnchor(hash.slice(1));
+    } else if (returnStack.length) {
+      restoreView(returnStack.pop());
+    } else {
+      restoreDefaultView();
+    }
+  }
+
+  history.replaceState({ depth: 0 }, "", window.location.href);
+
+  document.addEventListener("click", function(event) {
+    const link = event.target.closest && event.target.closest('a[href^="#"]');
+
+    if (!link || link.getAttribute("data-bs-toggle") === "tab") {
+      return;
+    }
+
+    const id = hashLinkTargetId(link);
+
+    if (!id || !anchorTarget(id)) {
+      return;
+    }
+
+    event.preventDefault();
+    returnStack.push(captureCurrentView());
+    navigateToAnchor(id);
+    navDepth++;
+    history.pushState({ depth: navDepth }, "", "#" + id);
+    lastNavigatedHash = "#" + id;
+  });
+
+  window.addEventListener("popstate", function(event) {
+    handleHistoryNavigation(event, true);
+  });
+
+  window.addEventListener("hashchange", function(event) {
+    handleHistoryNavigation(event, false);
+  });
+
+  if (window.location.hash.length > 1) {
+    navigateToAnchor(window.location.hash.slice(1));
+    lastNavigatedHash = window.location.hash;
+  }
+
+  const tabsets = document.querySelectorAll(".panel-tabset");
+
+  tabsets.forEach(function(tabset) {
+    tabset.addEventListener("show.bs.tab", function() {
+      const tabContent = tabset.querySelector(".tab-content");
       if (tabContent) {
         tabContent.style.minHeight = tabContent.offsetHeight + "px";
       }
     });
 
-    tabset.addEventListener('shown.bs.tab', function () {
-      const tabContent = tabset.querySelector('.tab-content');
+    tabset.addEventListener("shown.bs.tab", function() {
+      const tabContent = tabset.querySelector(".tab-content");
       if (tabContent) {
-        // Release height after transition
         tabContent.style.minHeight = "";
       }
-
-      // Force DataTables to recalc layout if any are visible
-      if (window.jQuery && window.jQuery.fn && window.jQuery.fn.dataTable) {
-        window.jQuery.fn.dataTable.tables({ visible: true }).forEach(function (table) {
-          window.jQuery(table).DataTable().columns.adjust();
-        });
-      }
     });
-
   });
 
 });

--- a/inst/quarto/pixelatorES.qmd
+++ b/inst/quarto/pixelatorES.qmd
@@ -1,6 +1,6 @@
 ---
 title: "PROXIOME EXPERIMENT SUMMARY"
-subtitle: "v0.11.2"
+subtitle: "v0.11.3"
 date: "`r Sys.Date()`"
 editor_options: 
   chunk_output_type: console

--- a/inst/quarto/styles.css
+++ b/inst/quarto/styles.css
@@ -87,3 +87,9 @@ p.subtitle {
 #toc-title {
   display: none;
 }
+
+.plot-anchor {
+  height: 0;
+  margin: 0;
+  padding: 0;
+}

--- a/man/tabset_nested_plotlist.Rd
+++ b/man/tabset_nested_plotlist.Rd
@@ -4,7 +4,7 @@
 \alias{tabset_nested_plotlist}
 \title{Tabset nested plots}
 \usage{
-tabset_nested_plotlist(plots, level = 2, close = TRUE)
+tabset_nested_plotlist(plots, level = 2, close = TRUE, anchor_prefix = NULL)
 }
 \arguments{
 \item{plots}{List of plots or list of lists of plots to be tabsetted.}
@@ -12,6 +12,9 @@ tabset_nested_plotlist(plots, level = 2, close = TRUE)
 \item{level}{Integer indicating the header level for the tabset title (default is 2).}
 
 \item{close}{Logical indicating whether to close the tabset after plotting (default is TRUE).}
+
+\item{anchor_prefix}{Prefix for in-report deep-link anchor IDs. \code{NULL} (default)
+auto-detects from the current knitr chunk label; pass a string to override.}
 }
 \value{
 A formatted tabset of plots.

--- a/man/tabset_plotlist.Rd
+++ b/man/tabset_plotlist.Rd
@@ -4,7 +4,7 @@
 \alias{tabset_plotlist}
 \title{Tabset plots}
 \usage{
-tabset_plotlist(plots, level = 2, close = TRUE)
+tabset_plotlist(plots, level = 2, close = TRUE, anchor_prefix = NULL)
 }
 \arguments{
 \item{plots}{List of plots to be tabsetted.}
@@ -12,6 +12,9 @@ tabset_plotlist(plots, level = 2, close = TRUE)
 \item{level}{Integer indicating the header level for the tabset title (default is 2).}
 
 \item{close}{Logical indicating whether to close the tabset after plotting (default is TRUE).}
+
+\item{anchor_prefix}{Prefix for in-report deep-link anchor IDs. \code{NULL} (default)
+auto-detects from the current knitr chunk label; pass a string to override.}
 }
 \value{
 A formatted tabset of plots.

--- a/man/title_plotlist.Rd
+++ b/man/title_plotlist.Rd
@@ -4,12 +4,15 @@
 \alias{title_plotlist}
 \title{Header wrap plots}
 \usage{
-title_plotlist(plots, level = 2)
+title_plotlist(plots, level = 2, anchor_prefix = NULL)
 }
 \arguments{
 \item{plots}{List of plots to be wrapped.}
 
 \item{level}{Integer indicating the header level for the headers (default is 2).}
+
+\item{anchor_prefix}{Prefix for in-report deep-link anchor IDs. \code{NULL} (default)
+auto-detects from the current knitr chunk label; pass a string to override.}
 }
 \value{
 A formatted list of plots with headers.

--- a/tests/testthat/test_plot_helpers.R
+++ b/tests/testthat/test_plot_helpers.R
@@ -7,24 +7,24 @@ test_that("Tab setting and title setting work as expected", {
     list("a" = g, "b" = g, "c" = g)
 
   expect_equal(
-    capture.output(title_plotlist(plot_list)),
+    capture.output(title_plotlist(plot_list, anchor_prefix = NULL)),
     c("## a", "", "", "", "## b", "", "", "", "## c", "", "", "")
   )
   expect_equal(
-    capture.output(title_plotlist(plot_list, level = 3)),
+    capture.output(title_plotlist(plot_list, level = 3, anchor_prefix = NULL)),
     c("### a", "", "", "", "### b", "", "", "", "### c", "", "", "")
   )
 
 
   expect_equal(
-    capture.output(tabset_plotlist(plot_list)),
+    capture.output(tabset_plotlist(plot_list, anchor_prefix = NULL)),
     c(
       "::: {.panel-tabset .nav-pills}", "## a", "", "", "", "## b",
       "", "", "", "## c", "", "", "", ":::"
     )
   )
   expect_equal(
-    capture.output(tabset_plotlist(plot_list, level = 3)),
+    capture.output(tabset_plotlist(plot_list, level = 3, anchor_prefix = NULL)),
     c(
       "::: {.panel-tabset .nav-pills}", "### a", "", "", "", "### b",
       "", "", "", "### c", "", "", "", ":::"
@@ -43,12 +43,12 @@ test_that("Tab setting and title setting work as expected", {
   plot_list <-
     list("a" = g, "b" = g, "c" = g_bad)
 
-  expect_no_error(title_plotlist(plot_list))
+  expect_no_error(title_plotlist(plot_list, anchor_prefix = NULL))
 
   ## Throw error in dev mode
   options(pixelatorES.dev_mode = TRUE)
 
-  expect_error(title_plotlist(plot_list))
+  expect_error(title_plotlist(plot_list, anchor_prefix = NULL))
 
   options(pixelatorES.dev_mode = FALSE)
 
@@ -64,7 +64,7 @@ test_that("Tab setting and title setting work as expected", {
     )
 
   expect_equal(
-    capture.output(tabset_nested_plotlist(nested_plot_list, level = 3)),
+    capture.output(tabset_nested_plotlist(nested_plot_list, level = 3, anchor_prefix = NULL)),
     c(
       "", "", "::: {.panel-tabset .nav-pills}", "### a", "", "",
       "", "### b", "", "", "", "### c", "", "", "", "### plot_list",
@@ -72,6 +72,43 @@ test_that("Tab setting and title setting work as expected", {
       "#### b", "", "", "", "#### c", "", "", "", ":::", ":::"
     )
   )
+})
+
+test_that("plot anchor slugs are stable and URL-safe", {
+  expect_equal(pixelatorES:::plot_anchor_slug("HLA-DR"), "hla-dr")
+  expect_equal(
+    pixelatorES:::plot_anchor_slug("abundance_per_marker", "CD3"),
+    "abundance-per-marker-cd3"
+  )
+})
+
+test_that("title_plotlist emits anchor divs when anchor_prefix is set", {
+  g <- ggplot() + theme_void()
+  plot_list <- list("CD3" = g, "HLA-DR" = g)
+
+  out <- capture.output(
+    title_plotlist(plot_list, level = 5, anchor_prefix = "abundance-per-marker")
+  )
+
+  expect_true(any(grepl('data-anchor-id="abundance-per-marker-cd3"', out)))
+  expect_true(any(grepl('data-anchor-id="abundance-per-marker-hla-dr"', out)))
+})
+
+test_that("tabset_nested_plotlist extends anchor prefixes for nested tabs", {
+  g <- ggplot() + theme_void()
+  nested_plot_list <- list(
+    "B cell" = list("CD19" = g)
+  )
+
+  out <- capture.output(
+    tabset_nested_plotlist(
+      nested_plot_list,
+      level = 3,
+      anchor_prefix = "coloc-celltype"
+    )
+  )
+
+  expect_true(any(grepl('data-anchor-id="coloc-celltype-b-cell-cd19"', out)))
 })
 
 test_that("Embedding plots work as expected", {


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

-->

## Description

Fixed a plot bug and added tabset anchors that can be used to navigate throughout the ES using links.

### Added

- In-report deep-link anchor IDs for plot tabsets (`title_plotlist`, `tabset_plotlist`, `tabset_nested_plotlist`). Anchor IDs are derived from the knitr chunk label and tab name (e.g. `#abundance-per-marker-cd3`, `#qc-metrics-sequencing-saturation-s11`).
- ES report hash navigation in `custom.html`: opens nested tab panes for `#` links, scrolls to the target, refreshes HTMLWidgets and DataTables in newly shown tabs, and restores tab/scroll state on browser back.

### Fixed

- Bug in `component_denoising` in the isotype reduction plot, where components with zero isotype counts would cause the summary median to become `NAs`.

## Type of change

- [x] Bug fix 
- [x] New feature
- [ ] Breaking change 

## How Has This Been Tested?

Manual tests.

## PR checklist:

- [x] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [x] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)
