### PR TITLE
fix: undetermined bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.4] 2026-07-21
+
+### Fixed
+
+- Bug which would cause the sample confidence / hashing enrichment ratio of undetermined to not be displayed for undetermined cells in the sample confidence plot. 
+
 ## [0.11.3] 2026-06-23
 
 ### Added

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pixelatorES
 Title: Proxiome Experiment Summary
-Version: 0.11.3
+Version: 0.11.4
 Authors@R: 
     c(
     person("Max", "Karlsson", , "max.karlsson@pixelgen.com", role = c("aut", "cre"),

--- a/R/key_table.R
+++ b/R/key_table.R
@@ -669,7 +669,7 @@ get_qc_metrics <-
         # If the table contains a "sample" column but not a "sample_alias" column, add it from samplesheet
         if ("sample" %in% names(tb) && !"sample_alias" %in% names(tb)) {
           tb <- tb %>%
-            inner_join(
+            left_join(
               select(sample_sheet, sample_alias, sample),
               by = c("sample")
             ) %>%

--- a/R/key_table.R
+++ b/R/key_table.R
@@ -674,6 +674,7 @@ get_qc_metrics <-
               by = c("sample")
             ) %>%
             mutate(sample_alias = ifelse(sample == "undetermined", "undetermined", sample_alias)) %>%
+            filter(!is.na(sample_alias)) %>%
             select(-sample)
         }
 

--- a/inst/quarto/pixelatorES.qmd
+++ b/inst/quarto/pixelatorES.qmd
@@ -1,6 +1,6 @@
 ---
 title: "PROXIOME EXPERIMENT SUMMARY"
-subtitle: "v0.11.3"
+subtitle: "v0.11.4"
 date: "`r Sys.Date()`"
 editor_options: 
   chunk_output_type: console

--- a/tests/testthat/test_key_table.R
+++ b/tests/testthat/test_key_table.R
@@ -655,6 +655,15 @@ for (data_type in data_types) {
       sample_qc_tables <-
         get_qc_metrics(seur, sample_qc_metrics, sample_sheet)
     )
+
+    # Regression test: undetermined entries in component_sample_confidence are
+    # preserved with sample_alias == "undetermined" after sample -> sample_alias mapping
+    if (data_type == "hashing") {
+      conf <- sample_qc_tables$sample_hash_stats$component_sample_confidence
+      expect_true("undetermined" %in% conf$sample_alias)
+      expect_true(all(!is.na(conf$sample_confidence[conf$sample_alias == "undetermined"])))
+    }
+
     expect_no_error(
       tabl <- key_metric_table(sample_qc_tables)
     )


### PR DESCRIPTION
<!--

Please fill in the appropriate checklist below (delete whatever is not relevant).

-->

## Description

### Fixed

- Bug which would cause the sample confidence / hashing enrichment ratio of undetermined to not be displayed for undetermined cells in the sample confidence plot. 

## Type of change

- [x] Bug fix 
- [ ] New feature
- [ ] Breaking change 

## How Has This Been Tested?

Manual testing.

## PR checklist:

- [x] I have run R CMD check on the package and it passes.
- [ ] I have made changes to the documentation.
- [ ] I have added tests.
- [x] I have documented any significant changes in [CHANGELOG.md](../CHANGELOG.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small QC formatting change with a targeted regression test; no auth, data pipeline, or API surface changes beyond report display.
> 
> **Overview**
> **Fixes missing undetermined metrics** in the sample confidence / hashing enrichment plot for hashed experiments. Pool-level QC includes an `undetermined` sample that is not on the samplesheet; mapping `sample` → `sample_alias` used `inner_join`, which dropped those rows.
> 
> In `get_qc_metrics` formatting (`.format` in `key_table.R`), the join is now **`left_join`**, **`undetermined` is forced to `sample_alias == "undetermined"`**, and rows with no resolved alias are removed with **`filter(!is.na(sample_alias))`** so only unmatched non-undetermined rows drop.
> 
> Release **0.11.4** (`DESCRIPTION`, report subtitle, `CHANGELOG.md`). A **hashing regression test** asserts `component_sample_confidence` still contains `undetermined` with non-NA confidence values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b6679dea9022db761f87b69e59ee28be3790f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->