### PR TITLE
Count well-connected nodes as coreness ≥ 3

### DIFF
--- a/R/components.R
+++ b/R/components.R
@@ -1223,14 +1223,14 @@ component_coreness <-
         y_label = "Dangling nodes [%]", round = 2
       )
 
-    # Well-connected nodes - % coreness 3-5
+    # Well-connected nodes - % coreness >= 3
     p3 <-
       qc_metrics_tables$coreness$component_summary %>%
       plot_violin(
         x = "sample_alias",
         y = "percent_well_connected_nodes",
         title = "Percent well-connected nodes",
-        subtitle = "The percentage of nodes with coreness 3-5",
+        subtitle = "The percentage of nodes with coreness 3 or higher",
         y_label = "Well-connected nodes [%]",
         round = 2
       )

--- a/R/key_table.R
+++ b/R/key_table.R
@@ -355,7 +355,7 @@ get_coreness_data <-
       summarise(
         mean_coreness = weighted.mean(coreness, nodes),
         percent_dangling_nodes = percent_nodes[coreness == 1],
-        percent_well_connected_nodes = sum(percent_nodes[coreness %in% 3:5])
+        percent_well_connected_nodes = sum(percent_nodes[coreness >= 3])
       )
 
     k_coreness_summary_sample <-
@@ -1077,7 +1077,7 @@ key_metric_definitions <-
     indicating the proportion of nodes that have a coreness of 1.",
     "median_percent_well_connected_nodes", "Median % well connected nodes", 1,
     "Median percentage of well-connected nodes in the sample,
-    indicating the proportion of nodes that have a coreness of 3-5.",
+    indicating the proportion of nodes that have a coreness of 3 or higher.",
     "top3_fraction", "Top 3 % counts", 1e-2,
     "Percentage of counts attributed to the top 3 abundant markers in the sample.",
     "top5_fraction", "Top 5 % counts", 1e-2,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Updates the well-connected nodes coreness QC metric to include nodes with coreness **3 or higher**, removing the previous upper limit of 5.
- Adjusts the related plot subtitle and key-metric description text to match.

## Changes
- `get_coreness_data()` in `R/key_table.R`: `coreness %in% 3:5` → `coreness >= 3`
- `component_coreness()` in `R/components.R`: subtitle/comment updated
- Key metric definition text updated accordingly

Existing unit-test expectations should remain valid for the current fixtures (max coreness in test data is ≤ 4).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c4eda27-8198-4751-b918-3f16a8fe97c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c4eda27-8198-4751-b918-3f16a8fe97c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

